### PR TITLE
fix: disable autologin when not selected

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -5,7 +5,7 @@ import { syncMoodleCalendarUrl } from '@/features/moodle-calendar-url/background
 import { sendSyncProgress, stopSync, syncCourses } from '@/features/search-sync/background'
 import { onMessage, sendMessageToMoodleTabs } from '@/shared/messages'
 import { refreshToken } from '@/shared/moodle-ws-api/token-store'
-import { getStored } from '@/shared/storage'
+import { getStored, setStored } from '@/shared/storage'
 
 chrome.runtime.onInstalled.addListener(() => {
   applyUserAgentRule()
@@ -20,6 +20,17 @@ onMessage('POPUP_OPEN', () => {
 
 onMessage('MOODLE_LOAD', () => {
   console.log('Background has received a message MOODLE_LOAD')
+  // Initialize variables in the storage
+  getStored('autologinEnabled').then((stored) => {
+    if (stored === undefined) {
+      setStored('autologinEnabled', true)
+    }
+  })
+  getStored('allowSyncingCourses').then((stored) => {
+    if (stored === undefined) {
+      setStored('allowSyncingCourses', true)
+    }
+  })
   getStored('autologinLastSuccessMS').then((autologinLastSuccessMS) => {
     sendMessageToMoodleTabs('AUTOLOGIN_LAST_SUCCESS', autologinLastSuccessMS)
   })

--- a/src/features/autologin/content-script.ts
+++ b/src/features/autologin/content-script.ts
@@ -5,18 +5,20 @@ import {
   MOODLE_OAUTH2_LOGIN_URL,
 } from '@/shared/config/moodle'
 import { sendMessage } from '@/shared/messages'
-import { setStored } from '@/shared/storage'
+import { getStored, setStored } from '@/shared/storage'
 
 export function requestAutologinIfNeeded() {
-  if (window.location.href.startsWith(MOODLE_LOGIN_URL) || window.location.href.startsWith(MOODLE_OAUTH2_LOGIN_URL)) {
-    sendMessage('REQUEST_AUTOLOGIN')
-  }
-  else if (window.location.href.startsWith(MOODLE_MOBILE_LAUNCH_URL)) {
-    window.location.href = MOODLE_DASHBOARD_URL
-  }
-  else if (document.body.classList.contains('notloggedin')) {
-    sendMessage('REQUEST_AUTOLOGIN')
-  }
+  getStored('autologinEnabled').then((enabled) => {
+    if ((window.location.href.startsWith(MOODLE_LOGIN_URL) || window.location.href.startsWith(MOODLE_OAUTH2_LOGIN_URL)) && enabled) {
+      sendMessage('REQUEST_AUTOLOGIN')
+    }
+    else if (window.location.href.startsWith(MOODLE_MOBILE_LAUNCH_URL)) {
+      window.location.href = MOODLE_DASHBOARD_URL
+    }
+    else if (document.body.classList.contains('notloggedin') && enabled) {
+      sendMessage('REQUEST_AUTOLOGIN')
+    }
+  })
 }
 
 export function refreshPageOnAutologin() {


### PR DESCRIPTION
### Description of changes
1. Check if autologin is enabled with `getStored` method in `requestAutoLoginIfNeeded`
2. Initialize `autologinEnabled` and `allowSyncingCourses` on moodle load 