### PR TITLE
fix: check the user email before synchronizing moodle calendar

### DIFF
--- a/src/features/moodle-calendar-url/background.ts
+++ b/src/features/moodle-calendar-url/background.ts
@@ -22,6 +22,12 @@ export async function syncMoodleCalendarUrl() {
     return false
   }
 
+  const siteInfo = await moodle.core.webservice.getSiteInfo({})
+  if (user.email !== siteInfo.username) {
+    console.log('Moodle account does not match InNoHassle account')
+    return false
+  }
+
   try {
     const { token } = await moodle.core.calendar.getCalendarExportToken({})
     if (!token) {


### PR DESCRIPTION
### Description of changes
Use Moodle client method `moodle.core.webservice.getSiteInfo({})` to get the username and compare it to the `user.email` before synchronizing calendar